### PR TITLE
default into should return Any

### DIFF
--- a/src/forge.jl
+++ b/src/forge.jl
@@ -84,7 +84,7 @@ postprocessor(::Forge, ::Function) = DoNothing()
 Returns the type that the [`PostProcessor`](@ref) should create from the response.
 
 """
-into(::Forge, ::Function) = Nothing
+into(::Forge, ::Function) = Any
 
 """
     endpoint(::Forge, ::Function, args...) -> Endpoint


### PR DESCRIPTION
I was prototyping for something I might want to add to GitForge.jl
and I was using `request` directly.
I was, to my surprise getting a really cryptic error.
Even though AFAICT I was doing what the docstring of `request` said to.
And the reason was by cause I had not declared an `into` foor the `f` i was passing into `request`.

The safe default is for this to be `Any`.
Julia being a dynamic language anyway...