### PR TITLE
fix type check on 2 args json

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -33,7 +33,7 @@ macro json(forgesym::Symbol, def::Expr)
     catch
         throw("No struct named $forgesym, pass a valid API to @json $(def.args[2])")
     end
-    !(forge <: GitForge.ForgeType) && throw("$forge is not a ForgeType, pass a valid API to @json $(def.args[2])")
+    !(forge <: GitForge.Forge) && throw("$forge is not a Forge, pass a valid API to @json $(def.args[2])")
     json(forge, def)
 end
 


### PR DESCRIPTION
I started trying out this package to interact with the GitLab API on a self-hosted instance and encountered an error when trying to use the 2 argument `@json` macro to add things endpoints and types to the GitLabAPI.

I believe the type check in the 2 argument `@json` macro is wrong, as the APIs seems to be of type `Forge` rather than `ForgeType`.

This is based on the 1 argument definition of `@json` (which calls the same 2-argument function `json` as the 2-argument macro):
https://github.com/JuliaWeb/GitForge.jl/blob/f8df114223524ce7d8debdddda369c406ae3f156/src/helpers.jl#L21-L28

which simply extracts the struct `$(ModuleName)API` which always seems of type `Forge` rather than `ForgeType`:
- https://github.com/JuliaWeb/GitForge.jl/blob/f8df114223524ce7d8debdddda369c406ae3f156/src/forges/GitLab/GitLab.jl#L83
- https://github.com/JuliaWeb/GitForge.jl/blob/f8df114223524ce7d8debdddda369c406ae3f156/src/forges/GitHub/GitHub.jl#L79
