### PR TITLE
disallow path navigation and newlines in urls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -191,7 +191,7 @@ struct Endpoint
         if occursin(r"\.\.", url)
             throw(ArgumentError("URLs cannot contain path navigation"))
         end
-        # do not allow new lines or carraige returns in URLs
+        # do not allow new lines or carriage returns in URLs
         if occursin(r"[\r\n]", url)
             throw(ArgumentError("URLs cannot contain line breaks"))
         end

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -192,7 +192,7 @@ struct Endpoint
             throw(ArgumentError("URLs cannot contain path navigation"))
         end
         # do not allow new lines or carriage returns in URLs
-        if occursin(r"[\r\n]", url)
+        if occursin(r"\s", url)
             throw(ArgumentError("URLs cannot contain line breaks"))
         end
         return new(method, url, headers, query, allow_404)

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -187,6 +187,14 @@ struct Endpoint
         query::Dict=Dict(),
         allow_404::Bool=false,
     )
+        # do not allow path navigation in URLs
+        if occursin(r"\.\.", url)
+            throw(ArgumentError("URLs cannot contain path navigation"))
+        end
+        # do not allow new lines or carraige returns in URLs
+        if occursin(r"[\r\n]", url)
+            throw(ArgumentError("URLs cannot contain line breaks"))
+        end
         return new(method, url, headers, query, allow_404)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,16 @@ GF.into(::TestForge, ::typeof(get_user)) = Symbol
         @test haskey(get(body, :args, Dict()), :foo)
         @test get(get(body, :args, Dict()), :a, "") == "b"
     end
+
+    @testset "URL sanity" begin
+        @test isa(GitForge.Endpoint(:GET, "/repos/owner/repo"), GitForge.Endpoint)
+        @test_throws ArgumentError GitForge.Endpoint(:GET, "/repos/owner1/../owner2/repo")
+        @test_throws ArgumentError GitForge.Endpoint(:GET, "/repos/owner1/\n/owner2/repo")
+        @test_throws ArgumentError GitForge.Endpoint(:GET, "/repos/owner1/\r\nfoo/owner2/repo")
+
+        forge = GitForge.GitHub.GitHubAPI(;token=GitForge.GitHub.NoToken())
+        @test_throws ArgumentError GitForge.get_repo(forge, "JuliaLang", "../octocat/Hello-World")
+    end
 end
 
 # test whether apis are conformant


### PR DESCRIPTION
Adding checks to `Endpoint` urls to disallow:
- path navigation. This would prevent API calls like `GitForge.get_repo(forge, "JuliaLang", "../octocat/Hello-World")` from succeeding. Helps avoid possible security loopholes.
- newlines. This would prevent possible security loopholes using HTTP protocol.

Also added some tests.