### PR TITLE
Require HTTP.jl v1.10.17, and bump patch version (GitForge.jl 0.4.3 --> 0.4.4)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitForge"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 authors = ["Chris de Graaf <me@cdg.dev>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-HTTP = "0.9, 1"
+HTTP = "1.10.17" # Must be >= 1.10.17, see https://github.com/JuliaWeb/GitForge.jl/pull/51
 JSON3 = "1"
 StructTypes = "1"
 TimeZones = "1"


### PR DESCRIPTION
We need HTTP v1.10.17 in order to get https://github.com/JuliaWeb/HTTP.jl/pull/1225, which in turn gives us https://github.com/JuliaWeb/URIs.jl/pull/66