### PR TITLE
WIP: `Endpoint()` constructor: Roundtrip the URL through `URIs.resolvereference()`, and make sure it is unchanged

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
@@ -16,11 +17,12 @@ HTTP = "0.9, 1"
 JSON3 = "1"
 StructTypes = "1"
 TimeZones = "1"
+URIs = "1.6" # Must be >= 1.6, to get https://github.com/JuliaWeb/URIs.jl/pull/66
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Logging"]

--- a/src/GitForge.jl
+++ b/src/GitForge.jl
@@ -6,6 +6,7 @@ using Base.StackTraces: StackTrace
 using Dates
 using Dates: Period, UTC, now
 using HTTP: HTTP
+using URIs: URIs
 using UUIDs: UUID
 using JSON3: JSON3, @writechar, @check, realloc!
 using StructTypes: StructTypes, UnorderedStruct, StructType, DictType, StringType

--- a/src/forge.jl
+++ b/src/forge.jl
@@ -187,10 +187,19 @@ struct Endpoint
         query::Dict=Dict(),
         allow_404::Bool=false,
     )
-        # do not allow path navigation in URLs
+        # Do not allow path navigation in URLs
+        # Disallowed pattern: ..
         if occursin(r"\.\.", url)
             throw(ArgumentError("URLs cannot contain path navigation"))
         end
+
+        # Additional disallowed patterns:
+        # ../, ..\, /.., \.., ./, .\, /./, \.\
+        PATH_TRAVERSAL = r"(?:\.{2,}[\/\\]|\.{1,}[\/\\]|[\/\\]\.{2,}|[\/\\]\.{1,}[\/\\])"
+        if occursin(PATH_TRAVERSAL, url)
+            throw(ArgumentError("URLs cannot contain path navigation"))
+        end
+
         # do not allow new lines or carriage returns in URLs
         if occursin(r"\s", url)
             throw(ArgumentError("URLs cannot contain line breaks"))


### PR DESCRIPTION
This serves as an additional sanity check that the endpoint URL doesn't contain any path traversal.

On its own, I don't think this is sufficient, so I think we should still keep the existing checks.